### PR TITLE
Enable removeOptionalTags html-minifier setting

### DIFF
--- a/_11ty/optimize-html.js
+++ b/_11ty/optimize-html.js
@@ -92,6 +92,7 @@ const minifyHtml = (rawContent, outputPath) => {
       sortAttributes: true,
       html5: true,
       decodeEntities: true,
+      removeOptionalTags: true,
     });
   }
   return content;


### PR DESCRIPTION
This setting omits e.g. `</li>` and `</p>` where possible (which is still valid HTML).