### PR TITLE
Make images `content-visibility: auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ npm run build
 - Transcodes images to [AVIF](https://en.wikipedia.org/wiki/AV1#AV1_Image_File_Format_(AVIF)) (currently off-by-default due to instabillity of the encoder) and [webp](https://developers.google.com/speed/webp) and generates `picture` element.
 - **Lazy loads** images (using [native `loading=lazy`](https://web.dev/native-lazy-loading/)).
 - **Async decodes** images (using `decoding=async`).
+- **Lazy layout** of images and placeholders using [`content-visibility: auto`](https://web.dev/content-visibility/#skipping-rendering-work-with-content-visibility).
 - **Avoids CLS impact** of images by inferring and providing width and height (Supported in Chrome, Firefox and Safari 14+).
 - Downloads remote images and stores/serves them locally.
 - Immutable URLs.

--- a/_11ty/img-dim.js
+++ b/_11ty/img-dim.js
@@ -63,11 +63,20 @@ const processImage = async (img, outputPath) => {
   if (img.tagName == "IMG") {
     img.setAttribute("decoding", "async");
     img.setAttribute("loading", "lazy");
+    // Contain the intrinsic to the `--main-width` (width of the main article body)
+    // and the aspect ratio times that size. But because images are `max-width: 100%`
+    // use the `min` operator to set the actual dimensions of the image as the
+    // ceiling 🤯.
+    const containSize = `min(var(--main-width), ${
+      dimensions.width
+    }px) min(calc(var(--main-width) * ${
+      dimensions.height / dimensions.width
+    }), ${dimensions.height}px)`;
     img.setAttribute(
       "style",
-      `background-size:cover;background-image:url("${await blurryPlaceholder(
-        src
-      )}")`
+      `background-size:cover;` +
+        `contain-intrinsic-size: ${containSize};` +
+        `background-image:url("${await blurryPlaceholder(src)}")`
     );
     const doc = img.ownerDocument;
     const picture = doc.createElement("picture");

--- a/css/main.css
+++ b/css/main.css
@@ -8,6 +8,29 @@
   color: red;
 }
 
+/*
+  Make image rasterization lazy. This means that e.g. the cost of the
+  blurry placeholder is never paid if images load before entering
+  the viewport.
+  Context
+  - https://web.dev/content-visibility/#skipping-rendering-work-with-content-visibility
+ */
+main img {
+  content-visibility: auto;
+}
+
+/*! purgecss start ignore */
+:root {
+  --main-width: calc(100vw - 3em);
+}
+
+@media (min-width: 37.5em) {
+  :root {
+    --main-width: calc(37.5em - 3em);
+  }
+}
+/*! purgecss end ignore */
+
 share-widget {
   position: fixed;
   right: 20px;


### PR DESCRIPTION
This makes it so that:

- Images are only decoded/rasterized when needed.
- The blurry placeholder (which can be expensive) is only ever rendered when images enter the viewport before they load.

The main work here is to generate the correct value for `contain-intrinsic-size`. This is achieved by:

- Defining a CSS variable with the width of the main article body
- Expressing the `contain-intrinsic-size` as a function of this and the image aspect ratio.
- Using the images `width` and `height`` as ceiling for the intrinsic size.

More info https://web.dev/content-visibility/#skipping-rendering-work-with-content-visibility