### PR TITLE
Fix images over navbar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -19,6 +19,12 @@ main img {
   content-visibility: auto;
 }
 
+/* "Content-visibility: auto" move the images over the other elements
+   Set z-index to keep the nav over the rasterized images */
+header nav {
+  z-index: 1;
+}
+
 /*! purgecss start ignore */
 :root {
   --main-width: calc(100vw - 3em);
@@ -388,7 +394,7 @@ BUGS:
   src: url("/fonts/Inter-italic.var.woff2") format("woff2");
 }
 
-/* 
+/*
 
 The Bahunya CSS framework https://kimeiga.github.io/bahunya/
 


### PR DESCRIPTION
"Content-visibility: auto" moves the images over the other elements.

![image](https://user-images.githubusercontent.com/25171375/93079883-1ddbff00-f68d-11ea-8bf5-6c0b2c765360.png)


Set z-index to keeps the nav over the rasterized images.

![image](https://user-images.githubusercontent.com/25171375/93080109-7a3f1e80-f68d-11ea-84d5-71ef91115dbc.png)
