### PR TITLE
Add oryx_prod_node_modules to fix compatibility with Azure Websites

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -9,3 +9,4 @@ third_party
 functions
 test
 src
+.oryx_prod_node_modules/


### PR DESCRIPTION
The folder being ignored is automatically brought in by Azure Static Website's default deployment mechanism, and will break the default build process of eleventy. Ignoring it fixes the issue of trying to syntax highlight files in that directory