### PR TITLE
Make updating the test "should have script elements" easier

### DIFF
--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -63,7 +63,8 @@ describe("check build output for a generic post", () => {
 
     it("should have script elements", () => {
       const scripts = doc.querySelectorAll("script[src]");
-      expect(scripts).to.have.length(GA_ID ? 2 : 1);
+      let has_ga_id = GA_ID ? 1 : 0;
+      expect(scripts).to.have.length(has_ga_id + 1); // NOTE: update this when adding more <script>
       expect(scripts[0].getAttribute("src")).to.match(
         /^\/js\/min\.js\?hash=\w+/
       );


### PR DESCRIPTION
This PR helps updating the test `should have script elements` easier: you only need to change ***one number*** instead of two in the old version.