### PR TITLE
Remove the redundant <h1>Tagged “{{ tag }}”</h1>

### DIFF
--- a/tags.njk
+++ b/tags.njk
@@ -15,7 +15,6 @@ eleventyComputed:
   title: Tagged “{{ tag }}”
 permalink: /tags/{{ tag }}/
 ---
-<h1>Tagged “{{ tag }}”</h1>
 
 {% set postslist = collections[ tag ] %}
 {% include "postslist.njk" %}


### PR DESCRIPTION
`<h1>Tagged “{{ tag }}”</h1>` is redundant since we already render the title `Tagged “{{ tag }}”`