### PR TITLE
Fix bug where tags contain illegal path characters like #

### DIFF
--- a/tags.njk
+++ b/tags.njk
@@ -13,7 +13,7 @@ pagination:
 layout: layouts/home.njk
 eleventyComputed:
   title: Tagged “{{ tag }}”
-permalink: /tags/{{ tag }}/
+permalink: /tags/{{ tag | slug }}/
 ---
 
 {% set postslist = collections[ tag ] %}


### PR DESCRIPTION
11ty fails to write the tag folder if you've got a tag like `c#`.