### PR TITLE
Restore tagList collection

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -163,6 +163,8 @@ module.exports = function (eleventyConfig) {
     return array.slice(0, n);
   });
 
+  eleventyConfig.addCollection("tagList", require("./_11ty/getTagList"));
+
   eleventyConfig.addPassthroughCopy("img");
   eleventyConfig.addPassthroughCopy("css");
   // We need to copy cached.js only if GA is used


### PR DESCRIPTION
It seems that tagList collection was accidentaly deleted in a previous commit.
This commit restore it to make **All tags** page working (/tags/).