### PR TITLE
.eleventyignore: Also ignore .netlify/ to avoid template rendering error

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,5 +1,6 @@
 .DS_Store
 .github/
+.netlify/
 _site/
 node_modules/
 package-lock.json


### PR DESCRIPTION
The error was reported at https://github.com/cdeleeuwe/netlify-plugin-submit-sitemap/issues/18. 
Since Netlify is also a growing service for hosting static sites, this will save people a lot of time debugging.