### PR TITLE
Allow for tags with spaces

### DIFF
--- a/tags-list.njk
+++ b/tags-list.njk
@@ -5,6 +5,6 @@ layout: layouts/home.njk
 <h1>Tags</h1>
 
 {% for tag in collections.tagList %}
-  {% set tagUrl %}/tags/{{ tag }}/{% endset %}
+  {% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}
   <a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a>
 {% endfor %}


### PR DESCRIPTION
Hello @cramforce,

I'm using tags with spaces (e.g. "Small Business"). Currently this leads to 404s as the links on the `/tags`-page aren't created correctly. This change pipes the tags through slug to fix it.

Cheers,
Peter 