### PR TITLE
Fixing double h1

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -59,7 +59,7 @@
     <header>
       <nav>
         <div id="nav">
-          <h1><a href="{{ '/' | url }}" title="Homepage">{{ metadata.title }}</a></h1>
+          <a href="{{ '/' | url }}" title="Homepage" class="title">{{ metadata.title }}</a>
           {#- Read more about `eleventy-navigation` at https://www.11ty.dev/docs/plugins/navigation/ #}
           {%- for entry in collections.all | eleventyNavigation %}
             <a href="{{ entry.url | url }}">{{ entry.title }}</a>

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -37,8 +37,8 @@ templateClass: tmpl-post
   "@type": "Article",
   "headline": "{{ title }}",
   "image": [],
-  "author": "{{ metadata.author.name }}", 
-  "genre": "{{ metadata.genre }}", 
+  "author": "{{ metadata.author.name }}",
+  "genre": "{{ metadata.genre }}",
   "publisher": {
     "@type": "Organization",
     "name": "{{ metadata.publisher.name }}",

--- a/css/main.css
+++ b/css/main.css
@@ -1060,7 +1060,7 @@ header nav {
   font-weight: 200;
   text-align: right;
 }
-header nav h1 {
+header nav .title {
   float: left;
   font-size: inherit;
   line-height: inherit;


### PR DESCRIPTION
Hey @cramforce 

I've noticed two h1 (bad SEO practice), this PR fixes this by converting the h1 in the nav bar into a regular string (with same styling).

Cheers,
Peter