### PR TITLE
Ensure page.url is defined before dereferncing it

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -84,7 +84,7 @@
           {{ content | safe }}
         {% endblock %}
 
-        {% if page.url.indexOf("/posts/") > -1 %}
+        {% if page.url and page.url.indexOf("/posts/") > -1 %}
           <p>Published <time datetime="{{ page.date | htmlDateString }}">{{ page.date | readableDate }}</time></p>
         {% endif %}
       </article>

--- a/posts/fifthpost.md
+++ b/posts/fifthpost.md
@@ -1,0 +1,9 @@
+---
+permalink: false
+title: This is my fifth post.
+description: Draft
+date: 2021-06-22
+layout: layouts/post.njk
+---
+
+TBD...


### PR DESCRIPTION
When a post has `permalink` set to false, though no output file is
generated, the file is still processed with the `url` property set to
false. Thus, the expression in base.njk testing the `url` property must
ensure page.url is defined in advance.