### PR TITLE
Fix tiny gap in code snippets

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1183,6 +1183,9 @@ pre[class*="language-"] {
   -ms-hyphens: none;
   hyphens: none;
 }
+code[class*="language-"] {
+  padding: 0;
+}
 pre[class*="language-"] {
   padding: 1em;
   margin: 0.5em 0;


### PR DESCRIPTION
As done in Kimeiga/bahunya#8. I found that this template has that behavior, too.

Before,
![tiny-gap](https://user-images.githubusercontent.com/70360519/130941915-7aa61f1a-0c95-43bd-b89f-539d2b58819f.png)

After,
![image](https://user-images.githubusercontent.com/70360519/130942323-c4ed8273-bc5a-411b-9f45-95519a977ba5.png)
