### PR TITLE
Bump ffmpeg-static from 4.2.7 to 4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2181,9 +2181,9 @@
       }
     },
     "ffmpeg-static": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-4.2.7.tgz",
-      "integrity": "sha512-SGnOr2d+k0/9toRIv9t5/hN/DMYbm5XMtG0wVwGM1tEyXJAD6dbcWOEvfHq4LOySm9uykKL6LMC4eVPeteUnbQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-4.4.0.tgz",
+      "integrity": "sha512-NIJHVPXlSsIK9pYvsTPh4ZlppauorpPLLeOaIG7VOXWQck4Fx4Qi7Ahe+j8mj8KZXhWwCg3Hx46JdWAIOWLcpg==",
       "requires": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "csso": "^4.0.3",
     "datauri": "^3.0.0",
     "expect.js": "^0.3.1",
-    "ffmpeg-static": "^4.2.7",
+    "ffmpeg-static": "^4.4.0",
     "hasha": "^5.2.0",
     "html-minifier": "^4.0.0",
     "image-size": "^0.8.3",


### PR DESCRIPTION
Updates the `ffmpeg-static` dependency to v4.4.0 which adds [native support for Apple Silicon](https://github.com/eugeneware/ffmpeg-static/issues/83#issuecomment-866011992).