### PR TITLE
In dev mode, bypass 11ty and watch the css file ourself and reference…

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -166,7 +166,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addCollection("tagList", require("./_11ty/getTagList"));
 
   eleventyConfig.addPassthroughCopy("img");
-  eleventyConfig.addPassthroughCopy("css");
   // We need to copy cached.js only if GA is used
   eleventyConfig.addPassthroughCopy(GA_ID ? "js" : "js/*[!cached].*");
   eleventyConfig.addPassthroughCopy("fonts");
@@ -175,7 +174,6 @@ module.exports = function (eleventyConfig) {
   // We need to rebuild upon JS change to update the CSP.
   eleventyConfig.addWatchTarget("./js/");
   // We need to rebuild on CSS change to inline it.
-  eleventyConfig.addWatchTarget("./css/");
   // Unfortunately this means .eleventyignore needs to be maintained redundantly.
   // But without this the JS build artefacts doesn't trigger a build.
   eleventyConfig.setUseGitIgnore(false);

--- a/_data/csp.js
+++ b/_data/csp.js
@@ -27,8 +27,10 @@
  * or the comments at the end of the `CSP` const below.
  */
 
-const SELF = quote("self");
+const isDev = require("./isdevelopment");
 
+const SELF = quote("self");
+const UNSAFE_INLINE = quote("unsafe-inline");
 const CSP = {
   regular: serialize([
     // By default only talk to same-origin
@@ -38,7 +40,9 @@ const CSP = {
     // Script from same-origin and inline-hashes.
     ["script-src", SELF, /* Replaced by csp.js plugin */ "HASHES"],
     // Inline CSS is allowed.
-    ["style-src", quote("unsafe-inline")],
+    ["style-src", UNSAFE_INLINE],
+    // in serve mode, reference the css file for fast reload
+    ["style-src-elem", isDev ? SELF : UNSAFE_INLINE],
     // Images may also come from data-URIs.
     ["img-src", SELF, "data:"],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@11ty/eleventy-navigation": "^0.1.3",
     "@11ty/eleventy-plugin-rss": "^1.0.7",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
+    "chokidar": "^3.5.2",
     "eleventy-plugin-local-images": "^0.4.0",
     "file-type": "^12.0.1",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
… the stylesheet. This skips the lengthy 11ty rebuild and allows browsersync to reload only the css. Still inline it in build mode.

ATM I use `isDevelopment` (`argv.contains("--serve"`) to toggle the feature, not sure if that's the right way to do it.

remaining issue: a test expects a `style` tag, when in dev mode it should now expect a `link` tag.

# Before:
![MmKCyIGT3m](https://user-images.githubusercontent.com/1766559/135465578-2d5594bd-aabd-446f-a77b-43f21d57aadc.gif)

# After:
![ezgif-4-5b60036bc4e3](https://user-images.githubusercontent.com/1766559/135465995-f79d1b75-b78f-47a8-b4e9-bb2d658a258a.gif)

