### PR TITLE
Use CSP header instead of meta tag

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -197,8 +197,10 @@ module.exports = function (eleventyConfig) {
 
   // Browsersync Overrides
   eleventyConfig.setBrowserSyncConfig({
+    // read CSP headers from _headers file, add it to response
     middleware: function (req, res, next) {
       const url = new URL(req.originalUrl, `http://${req.headers.host}/)`);
+      // add csp headers only for html pages (incluse pretty urls)
       if (url.pathname.endsWith("/") || url.pathname.endsWith(".html")) {
         const pathNameEscaped = url.pathname.replace(/[.*+?^${}()\/|[\]\\]/g, '\\$&');
         // add CSP Policy
@@ -211,7 +213,7 @@ module.exports = function (eleventyConfig) {
             res.setHeader("Content-Security-Policy", match[2]);
           }
         } catch (error) {
-          console.log("[setBrowserSyncConfig] Something went wrong with the creation of the headers\n", error);
+          console.log("[setBrowserSyncConfig] Something went wrong with the creation of the csp headers\n", error);
         }
       }
       next();

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -173,7 +173,6 @@ module.exports = function (eleventyConfig) {
   // We need to copy cached.js only if GA is used
   eleventyConfig.addPassthroughCopy(GA_ID ? "js" : "js/*[!cached].*");
   eleventyConfig.addPassthroughCopy("fonts");
-  eleventyConfig.addPassthroughCopy("_headers");
 
   // We need to rebuild upon JS change to update the CSP.
   eleventyConfig.addWatchTarget("./js/");
@@ -231,6 +230,19 @@ module.exports = function (eleventyConfig) {
     },
     ui: false,
     ghostMode: false,
+  });
+
+  // Run me before the build starts
+  eleventyConfig.on('beforeBuild', () => {
+    // Copy _header to dist
+    // Don't use addPassthroughCopy to prevent apply-csp from running before the _header file has been copied
+    try {
+      const headers = fs.readFileSync("./_headers", { encoding: "utf-8" });
+      fs.mkdirSync("./_site", { recursive: true });
+      fs.writeFileSync("_site/_headers", headers);
+    } catch (error) {
+      console.log("[beforeBuild] Something went wrong with the _headers file\n", error);
+    }
   });
 
   return {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -163,7 +163,7 @@ module.exports = function (eleventyConfig) {
     return array.slice(0, n);
   });
 
-  
+
   eleventyConfig.addCollection("posts", function(collectionApi) {
     return collectionApi.getFilteredByTag("posts");
   });
@@ -197,6 +197,25 @@ module.exports = function (eleventyConfig) {
 
   // Browsersync Overrides
   eleventyConfig.setBrowserSyncConfig({
+    middleware: function (req, res, next) {
+      const url = new URL(req.originalUrl, `http://${req.headers.host}/)`);
+      if (url.pathname.endsWith("/") || url.pathname.endsWith(".html")) {
+        const pathNameEscaped = url.pathname.replace(/[.*+?^${}()\/|[\]\\]/g, '\\$&');
+        // add CSP Policy
+        try {
+          let headers = fs.readFileSync("_site/_headers", { encoding: "utf-8" });
+          // don't use literals string to avoid double escape
+          const pattern = "(" + pathNameEscaped + "\n  Content-Security-Policy: )(.*)";
+          const match = headers.match(new RegExp(pattern));
+          if (match) {
+            res.setHeader("Content-Security-Policy", match[2]);
+          }
+        } catch (error) {
+          console.log("[setBrowserSyncConfig] Something went wrong with the creation of the headers\n", error);
+        }
+      }
+      next();
+    },
     callbacks: {
       ready: function (err, browserSync) {
         const content_404 = fs.readFileSync("_site/404.html");

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ npm run build
 
 ### Security
 
-Generates a strong [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) for the base template.
+Generates a strong [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) using HTTP headers.
 
 - Default-src is self.
 - Disallows plugins.

--- a/_11ty/apply-csp.js
+++ b/_11ty/apply-csp.js
@@ -65,20 +65,6 @@ const addCspHash = async (rawContent, outputPath) => {
       hashes.push.apply(hashes, AUTO_RELOAD_SCRIPTS);
     }
 
-    // write CSP meta tag only for 404.html
-    // this guarantees at least a minimum csp policy for pages not found
-    if (outputPath === "_site/404.html") {
-      const csp = dom.window.document.querySelector(
-        "meta[http-equiv='Content-Security-Policy']"
-      );
-      if (csp) {
-        csp.setAttribute(
-          "content",
-          csp.getAttribute("content").replace("HASHES", hashes.join(" "))
-        );
-      }
-    }
-
     content = dom.serialize();
 
     // write CSP Policy in headers file
@@ -104,7 +90,8 @@ const addCspHash = async (rawContent, outputPath) => {
           "\n", filePath, "\n  ", CSPPolicy,
           "\n", filePathPrettyURL, "\n  ", CSPPolicy)
         : oldCustomHeaders.concat(
-          "\n", "/404.html", "\n  ", CSPPolicy)
+          "\n", "/404.html", "\n  ", CSPPolicy,
+          "\n", "/*", "\n  ", CSPPolicy);
       fs.writeFileSync(headersPath, headers.replace(regExp, `$1${newCustomHeaders}\n$3`));
     } catch (error) {
       console.log("[apply-csp] Something went wrong with the creation of the csp headers\n", error);

--- a/_11ty/apply-csp.js
+++ b/_11ty/apply-csp.js
@@ -65,6 +65,20 @@ const addCspHash = async (rawContent, outputPath) => {
       hashes.push.apply(hashes, AUTO_RELOAD_SCRIPTS);
     }
 
+    // write CSP meta tag only for 404.html
+    // this guarantees at least a minimum csp policy for pages not found
+    if (outputPath === "_site/404.html") {
+      const csp = dom.window.document.querySelector(
+        "meta[http-equiv='Content-Security-Policy']"
+      );
+      if (csp) {
+        csp.setAttribute(
+          "content",
+          csp.getAttribute("content").replace("HASHES", hashes.join(" "))
+        );
+      }
+    }
+
     content = dom.serialize();
 
     // write CSP Policy in headers file
@@ -84,9 +98,13 @@ const addCspHash = async (rawContent, outputPath) => {
       const oldCustomHeaders = headers.match(regExp)[2].toString();
       const CSPPolicy = `Content-Security-Policy: ${CSP.apply().regular.replace("HASHES", hashes.join(" "))}`;
       // write headers for full path (/blog/index.html) and pretty url (/blog/)
-      const newCustomHeaders = oldCustomHeaders.concat(
-        "\n", filePath, "\n  ", CSPPolicy,
-        "\n", filePathPrettyURL, "\n  ", CSPPolicy);
+      // 404.html require a different pattern.
+      const newCustomHeaders = (outputPath != "_site/404.html")
+        ? oldCustomHeaders.concat(
+          "\n", filePath, "\n  ", CSPPolicy,
+          "\n", filePathPrettyURL, "\n  ", CSPPolicy)
+        : oldCustomHeaders.concat(
+          "\n", "/404.html", "\n  ", CSPPolicy)
       fs.writeFileSync(headersPath, headers.replace(regExp, `$1${newCustomHeaders}\n$3`));
     } catch (error) {
       console.log("[apply-csp] Something went wrong with the creation of the csp headers\n", error);

--- a/_11ty/apply-csp.js
+++ b/_11ty/apply-csp.js
@@ -73,13 +73,13 @@ const addCspHash = async (rawContent, outputPath) => {
     const filePathPrettyURL = filePath.slice(0, -10); // blog/index.html ->  /blog/
     try {
       const headers = fs.readFileSync(headersPath, { encoding: "utf-8" });
-      const regExp = /(# \[custom headers\]\n)([\s\S]*)(# \[end custom headers\])/;
+      const regExp = /(# \[csp headers\]\n)([\s\S]*)(# \[end csp headers\])/;
       const match = headers.match(regExp);
       if (!match) {
-        throw `Check your _headers file. I couldn't find the text block for the custom headers:
-          # [custom headers]
+        throw `Check your _headers file. I couldn't find the text block for the csp headers:
+          # [csp headers]
           # this text will be replaced by apply-csp.js plugin
-          # [end custom headers]`;
+          # [end csp headers]`;
       }
       const oldCustomHeaders = headers.match(regExp)[2].toString();
       const CSPPolicy = `Content-Security-Policy: ${CSP.apply().regular.replace("HASHES", hashes.join(" "))}`;
@@ -89,7 +89,7 @@ const addCspHash = async (rawContent, outputPath) => {
         "\n", filePathPrettyURL, "\n  ", CSPPolicy);
       fs.writeFileSync(headersPath, headers.replace(regExp, `$1${newCustomHeaders}\n$3`));
     } catch (error) {
-      console.log("[apply-csp] Something went wrong with the creation of the headers\n", error);
+      console.log("[apply-csp] Something went wrong with the creation of the csp headers\n", error);
     }
   }
 

--- a/_11ty/apply-csp.js
+++ b/_11ty/apply-csp.js
@@ -22,6 +22,8 @@
 const { JSDOM } = require("jsdom");
 const cspHashGen = require("csp-hash-generator");
 const syncPackage = require("browser-sync/package.json");
+const fs = require("fs");
+const CSP = require("../_data/csp");
 
 /**
  * Substitute the magic `HASHES` string in the CSP with the actual values of the
@@ -63,19 +65,34 @@ const addCspHash = async (rawContent, outputPath) => {
       hashes.push.apply(hashes, AUTO_RELOAD_SCRIPTS);
     }
 
-    const csp = dom.window.document.querySelector(
-      "meta[http-equiv='Content-Security-Policy']"
-    );
-    if (!csp) {
-      return content;
-    }
-    csp.setAttribute(
-      "content",
-      csp.getAttribute("content").replace("HASHES", hashes.join(" "))
-    );
-
     content = dom.serialize();
+
+    // write CSP Policy in headers file
+    const headersPath = "./_site/_headers";
+    const filePath = outputPath.replace("_site/", "/"); // _site/blog/index.html ->  /blog/index.html
+    const filePathPrettyURL = filePath.slice(0, -10); // blog/index.html ->  /blog/
+    try {
+      const headers = fs.readFileSync(headersPath, { encoding: "utf-8" });
+      const regExp = /(# \[custom headers\]\n)([\s\S]*)(# \[end custom headers\])/;
+      const match = headers.match(regExp);
+      if (!match) {
+        throw `Check your _headers file. I couldn't find the text block for the custom headers:
+          # [custom headers]
+          # this text will be replaced by apply-csp.js plugin
+          # [end custom headers]`;
+      }
+      const oldCustomHeaders = headers.match(regExp)[2].toString();
+      const CSPPolicy = `Content-Security-Policy: ${CSP.apply().regular.replace("HASHES", hashes.join(" "))}`;
+      // write headers for full path (/blog/index.html) and pretty url (/blog/)
+      const newCustomHeaders = oldCustomHeaders.concat(
+        "\n", filePath, "\n  ", CSPPolicy,
+        "\n", filePathPrettyURL, "\n  ", CSPPolicy);
+      fs.writeFileSync(headersPath, headers.replace(regExp, `$1${newCustomHeaders}\n$3`));
+    } catch (error) {
+      console.log("[apply-csp] Something went wrong with the creation of the headers\n", error);
+    }
   }
+
 
   return content;
 };

--- a/_data/csp.js
+++ b/_data/csp.js
@@ -37,7 +37,7 @@ const CSP = {
     ["object-src", quote("none")],
     // Script from same-origin and inline-hashes.
     // If you need to add an external host for scripts you need to add an item like 'https://code.jquery.com/jquery-3.6.0.slim.min.js' to this list.
-    ["script-src", SELF, /* Replaced by csp.js plugin */ "HASHES"],
+    ["script-src", SELF, /* Replaced by apply-csp.js plugin */ "HASHES"],
     // Inline CSS is allowed.
     ["style-src", quote("unsafe-inline")],
     // Images may also come from data-URIs.

--- a/_data/csp.js
+++ b/_data/csp.js
@@ -37,7 +37,7 @@ const CSP = {
     ["object-src", quote("none")],
     // Script from same-origin and inline-hashes.
     // If you need to add an external host for scripts you need to add an item like 'https://code.jquery.com/jquery-3.6.0.slim.min.js' to this list.
-    ["script-src", SELF, /* Replaced by apply-csp.js plugin */ "HASHES", quote("unsafe-inline")],
+    ["script-src", SELF, /* Replaced by apply-csp.js plugin */ "HASHES"],
     // Inline CSS is allowed.
     ["style-src", quote("unsafe-inline")],
     // Images may also come from data-URIs.

--- a/_data/csp.js
+++ b/_data/csp.js
@@ -37,7 +37,7 @@ const CSP = {
     ["object-src", quote("none")],
     // Script from same-origin and inline-hashes.
     // If you need to add an external host for scripts you need to add an item like 'https://code.jquery.com/jquery-3.6.0.slim.min.js' to this list.
-    ["script-src", SELF, /* Replaced by apply-csp.js plugin */ "HASHES"],
+    ["script-src", SELF, /* Replaced by apply-csp.js plugin */ "HASHES", quote("unsafe-inline")],
     // Inline CSS is allowed.
     ["style-src", quote("unsafe-inline")],
     // Images may also come from data-URIs.

--- a/_headers
+++ b/_headers
@@ -12,6 +12,6 @@
 /favicon.svg
   cache-control: public,max-age=3600
 
-# [custom headers]
+# [csp headers]
 # this text will be replaced by apply-csp.js plugin
-# [end custom headers]
+# [end csp headers]

--- a/_headers
+++ b/_headers
@@ -11,3 +11,7 @@
   cache-control: public,max-age=31536000,immutable
 /favicon.svg
   cache-control: public,max-age=3600
+
+# [custom headers]
+# this text will be replaced by apply-csp.js plugin
+# [end custom headers]

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -8,6 +8,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% if page.url=="/404.html" %}
+    <meta http-equiv="Content-Security-Policy" content="{{ csp.regular | safe }}">
+    {% endif %}
     {% if isdevelopment %}
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     {% else %}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -8,9 +8,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {% if page.url=="/404.html" %}
-    <meta http-equiv="Content-Security-Policy" content="{{ csp.regular | safe }}">
-    {% endif %}
     {% if isdevelopment %}
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     {% else %}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -8,8 +8,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- See _data/csp.js for how to add to the CSP. -->
-    <meta http-equiv="Content-Security-Policy" content="{{ csp.regular | safe }}">
     {% if isdevelopment %}
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     {% else %}

--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -90,14 +90,7 @@ describe("check build output for a generic post", () => {
       expect(count).to.equal(1);
     });
 
-    it("should have a good CSP", () => {
-      const csp = select(
-        "meta[http-equiv='Content-Security-Policy']",
-        "content"
-      );
-      expect(csp).to.contain(";object-src 'none';");
-      expect(csp).to.match(/^default-src 'self';/);
-    });
+    // TODO: Check for a good CPS (_headers file)
 
     it("should have accessible buttons", () => {
       const buttons = doc.querySelectorAll("button");

--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -16,6 +16,7 @@ const GA_ID = require("../_data/googleanalytics.js")();
 describe("check build output for a generic post", () => {
   describe("sample post", () => {
     const POST_FILENAME = "_site/posts/firstpost/index.html";
+    const POST_RELATIVEFILENAME = "/posts/firstpost/index.html";
     const URL = metadata.url;
     const POST_URL = URL + "/posts/firstpost/";
 
@@ -90,7 +91,18 @@ describe("check build output for a generic post", () => {
       expect(count).to.equal(1);
     });
 
-    // TODO: Check for a good CPS (_headers file)
+    it("should have a good CSP", () => {
+      const pathNameEscaped = POST_RELATIVEFILENAME.replace(/[.*+?^${}()\/|[\]\\]/g, '\\$&');
+      assert(existsSync("./_site/_headers"),"_header exists");
+      const headers = readFileSync("./_site/_headers", { encoding: "utf-8" });
+      const pattern = "(" + pathNameEscaped + "\n  Content-Security-Policy: )(.*)";
+      const match = headers.match(new RegExp(pattern));
+      const csp = match ? match[2] : false;
+      assert(match,"There is a CSP header");
+      expect(csp).to.contain(";object-src 'none';");
+      expect(csp).to.match(/^default-src 'self';/);
+
+    });
 
     it("should have accessible buttons", () => {
       const buttons = doc.querySelectorAll("button");


### PR DESCRIPTION
An injection before the meta tag will bypass the CSP. Additionally, frame-ancestors, sandbox and reporting are not supported in meta tag CSPs. (https://web.dev/csp-xss/?utm_source=lighthouse&utm_medium=devtools#define-the-csp-in-an-http-header)

This pull request should be ensure CSP is effective against XSS attacks

Changes
1. Remove meta tag from base template
2. Add a block text to _header that will be replaced with the CSP headers
3. Write the CSP headers when run apply-csp (create an header for both full url and Pretty URL)
4. Override Browser-Synch configuration to read CSP headers from _headers file
5. Remove check for CSP meta tag in test (somebody can write a better test to check for a CSP header in _headers)
 
