### PR TITLE
fix(eleventyConfig): read 404.html on demand

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -205,11 +205,9 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.setBrowserSyncConfig({
     callbacks: {
       ready: function (err, browserSync) {
-        const content_404 = fs.readFileSync("_site/404.html");
-
         browserSync.addMiddleware("*", (req, res) => {
           // Provides the 404 content without redirect.
-          res.write(content_404);
+          res.write(fs.readFileSync("_site/404.html"));
           res.end();
         });
       },


### PR DESCRIPTION
In the old behaviour, when the user changes the content of `404.md`, they would need to restart the dev server in order for the change to take effect. This change effectively fixes the issue.