### PR TITLE
Fix code syntax highlight style issue when without given language

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -615,8 +615,12 @@ table {
 pre {
   font-family: Consolas, Monaco, Andale Mono, Ubuntu Mono, monospace;
 }
+pre:has(code:not([class])) {
+  background: #2d2d2d;
+}
 pre code:not([class]) {
-  padding: 1.5em;
+  color: #ccc;
+  padding: 0;
   overflow-x: scroll;
 }
 code,


### PR DESCRIPTION
# Issue

Code syntax highlight style broken when without given language (screenshot in below).


# Fix

Update style for `without given language`
- The value of `padding`, `background`, `color` are **SAME** with  other existed `<pre />, <code /> style`

## How to test
Past following text into any **Markdown** file and review it

> **```**
> redis> zrange zset 0 -1
> 1. "b"
> 2. "ba"
> 3. "bar"
> 4. "bar*"
> 5. "f"
> 6. "fo"
> 7. "foo"
> 8. "foo*"
> 9. "foob"
> 10. "fooba"
> 11. "foobar"
> 12. "foobar*"
> **```**


# Note

Currently **Firefox did NOT support `:has()`** yet, but it's looks acceptable (for this small fix).

See **Firefox screenshot** in blow

# Screenshot **Before**
<img width="1464" alt="Screen Shot 2023-02-15 at 17 38 52" src="https://user-images.githubusercontent.com/22259196/218995177-c0dddb00-890c-49a8-84be-e74d099f1e06.png">

# Screenshot **After, Brave**
<img width="1512" alt="Screen Shot 2023-02-15 at 17 39 59" src="https://user-images.githubusercontent.com/22259196/218995265-8a5daf3c-fab0-40e2-8e51-9b140c69ba22.png">

# Screenshot **After, Safari**
<img width="1512" alt="Screen Shot 2023-02-15 at 17 40 29" src="https://user-images.githubusercontent.com/22259196/218995357-a99b9da5-22a2-4459-ab39-7d03efd09d3a.png">

# Screenshot **After, Firefox**
![11ty_fix_firefox](https://user-images.githubusercontent.com/22259196/218995445-9c59982d-8563-43fa-8bb3-bee4ae4addeb.png)
