### PR TITLE
Remove Browsersync for Eleventy v2.x compatibility

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -201,21 +201,6 @@ module.exports = function (eleventyConfig) {
   });
   eleventyConfig.setLibrary("md", markdownLibrary);
 
-  // Browsersync Overrides
-  eleventyConfig.setBrowserSyncConfig({
-    callbacks: {
-      ready: function (err, browserSync) {
-        browserSync.addMiddleware("*", (req, res) => {
-          // Provides the 404 content without redirect.
-          res.write(fs.readFileSync("_site/404.html"));
-          res.end();
-        });
-      },
-    },
-    ui: false,
-    ghostMode: false,
-  });
-
   // After the build touch any file in the test directory to do a test run.
   eleventyConfig.on("afterBuild", async () => {
     const files = await readdir("test");

--- a/_11ty/apply-csp.js
+++ b/_11ty/apply-csp.js
@@ -21,25 +21,12 @@
 
 const { JSDOM } = require("jsdom");
 const cspHashGen = require("csp-hash-generator");
-const syncPackage = require("browser-sync/package.json");
 
 /**
  * Substitute the magic `HASHES` string in the CSP with the actual values of the
  * loaded JS files.
  * The ACTUAL CSP is configured in `_data/csp.js`.
  */
-
-// Allow the auto-reload script in local dev. Would be good to get rid of this magic
-// string which would break on ungrades of 11ty.
-const AUTO_RELOAD_SCRIPTS = [
-  quote(
-    cspHashGen(
-      "//<![CDATA[\n    document.write(\"<script async src='/browser-sync/browser-sync-client.js?v=" +
-        syncPackage.version +
-        '\'><\\/script>".replace("HOST", location.hostname));\n//]]>'
-    )
-  ),
-];
 
 function quote(str) {
   return `'${str}'`;
@@ -59,9 +46,6 @@ const addCspHash = async (rawContent, outputPath) => {
       element.setAttribute("csp-hash", hash);
       return quote(hash);
     });
-    if (isDevelopmentMode()) {
-      hashes.push.apply(hashes, AUTO_RELOAD_SCRIPTS);
-    }
 
     const csp = dom.window.document.querySelector(
       "meta[http-equiv='Content-Security-Policy']"
@@ -103,7 +87,3 @@ module.exports = {
     eleventyConfig.addTransform("csp", addCspHash);
   },
 };
-
-function isDevelopmentMode() {
-  return /serve|dev/.test(process.argv.join());
-}


### PR DESCRIPTION
A compatibility issue with Eleventy v2.x came up after a recent merge request "Bump axios and @11ty/eleventy #180". It updated Eleventy from 1.0.0 to 2.0.1
https://github.com/google/eleventy-high-performance-blog/actions/runs/6827178225/job/18568727206

In Eleventy v2 [Eleventy Dev Server](https://www.11ty.dev/docs/dev-server/) replaces Browsersync (https://github.com/11ty/eleventy/issues/1305).

So I removed the Browsersync related code.
[Eleventy Dev Server](https://www.11ty.dev/docs/dev-server/) has built-in support for `404.html`. 
And there is no need for additional CSP code. 